### PR TITLE
defaultCommandTimeout 10000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.0] - 2023-01-05
 
+- [#182](https://github.com/os2display/display-admin-client/pull/182)
+make cypress tests run 3 times in GA, and set defaultCommandTimeout to 10000 
 - [#178](https://github.com/os2display/display-admin-client/pull/178)
 add 8080 to port to make cypresstests run
 - [#177](https://github.com/os2display/display-admin-client/pull/177)

--- a/cypress.json
+++ b/cypress.json
@@ -4,8 +4,9 @@
   "pluginsFile": false,
   "supportFile": false,
   "viewportHeight": 4000,
+  "defaultCommandTimeout": 10000,
   "retries": {
-    "runMode": 2,
+    "runMode": 3,
     "openMode": 0
   }
 }


### PR DESCRIPTION
set defaultCommandTimeout to 10000 and make cypresstests run 3 times in GA (because they currently are flaky)