### PR TITLE
DISPLAY-986: Change docker image name to match repository name

### DIFF
--- a/.github/workflows/docker_build_develop.yml
+++ b/.github/workflows/docker_build_develop.yml
@@ -25,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: os2display/admin-client
+          images: os2display/display-admin-client
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- [#204](https://github.com/os2display/display-admin-client/pull/204)
+  Change docker image name from `os2display/os2display-admin-client` 
+  to `os2display/display-admin-client` to match image name and 
+  repository name
 - [#200](https://github.com/os2display/display-admin-client/pull/200)
   Update docker build to publish to "os2display" org on docker hup.
   Update github workflow to latest actions.
   Add github workflow to build and create release.
   Change `example_config.json` to use relative paths.
-
 - [#202](https://github.com/os2display/display-admin-client/pull/202)
   Remove zeroes when pagination button is not visible.
   Save campaign before redirect.

--- a/infrastructure/run.sh
+++ b/infrastructure/run.sh
@@ -5,6 +5,6 @@ set -eux
 APP_VERSION=develop
 VERSION=alpha
 
-docker build --pull --no-cache --build-arg APP_VERSION=${APP_VERSION} --tag=os2display/admin-client:${VERSION} --file="Dockerfile" .
+docker build --pull --no-cache --build-arg APP_VERSION=${APP_VERSION} --tag=os2display/display-admin-client:${VERSION} --file="Dockerfile" .
 
-# docker push os2display/admin-client:${VERSION}
+# docker push os2display/display-admin-client:${VERSION}


### PR DESCRIPTION
#### Link to ticket

DISPLAY-986

#### Description

Change docker image name from `os2display/os2display-admin-client` to `os2display/display-admin-client` to match image name and repository name

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
