### PR TITLE
Reverted change to rrule dtstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Reverted change in https://github.com/os2display/display-admin-client/commit/65762066c708f541305a48fbd6b28264dca593b5.
-- Added comments about how rrules are handled.
-
+- [#252](https://github.com/os2display/display-admin-client/pull/252)
+  - Reverted change in https://github.com/os2display/display-admin-client/commit/65762066c708f541305a48fbd6b28264dca593b5 regarding rrule dtstart.
+  - Added comments about how rrules are handled.
 - [#242](https://github.com/os2display/display-admin-client/pull/243)
-    - Add entry in example config for midttrafik api key
-    - Clean up multi select component a bit, replace reduce with Map logic
-    - Make the station selector call new api
-    - Add config to context in app.jsx
+  - Add entry in example config for midttrafik api key
+  - Clean up multi select component a bit, replace reduce with Map logic
+  - Make the station selector call new api
+  - Add config to context in app.jsx
 
 ## [2.0.3] - 2024-08-01
 
 - [#243](https://github.com/os2display/display-admin-client/pull/251)
-    - Fix null bug: replace valueAsDate with target.value as valueAsDate was null 
+  - Fix null bug: replace valueAsDate with target.value as valueAsDate was null
 
 ## [2.0.2] - 2024-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Reverted change in https://github.com/os2display/display-admin-client/commit/65762066c708f541305a48fbd6b28264dca593b5.
+- Added comments about how rrules are handled.
+
 - [#242](https://github.com/os2display/display-admin-client/pull/243)
     - Add entry in example config for midttrafik api key
     - Clean up multi select component a bit, replace reduce with Map logic

--- a/src/components/util/schedule/schedule-util.js
+++ b/src/components/util/schedule/schedule-util.js
@@ -11,6 +11,8 @@ dayjs.extend(localizedFormat);
 /**
  * Get rrule string from schedule.
  *
+ *
+ *
  * @param {object} schedule - The schedule.
  * @returns {string} - RRule string.
  */
@@ -56,7 +58,18 @@ const createNewSchedule = () => {
     id: ulid(nowTimestamp),
     duration: 60 * 60 * 24, // Default one day.
     freq: RRule.WEEKLY,
-    dtstart: new Date(),
+    // For evaluation with the RRule library we pretend that "now" is in UTC instead of the local timezone.
+    // That is 9:00 in Europe/Copenhagen time will be evaluated as if it was 9:00 in UTC.
+    // @see https://github.com/jkbrzt/rrule#important-use-utc-dates
+    dtstart: new Date(
+      Date.UTC(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        now.getHours(),
+        now.getMinutes()
+      )
+    ),
     until: null,
     wkst: RRule.MO,
     byhour: null,

--- a/src/components/util/schedule/schedule.jsx
+++ b/src/components/util/schedule/schedule.jsx
@@ -120,7 +120,17 @@ function Schedule({ schedules, onChange }) {
    */
   const setDateValue = (scheduleId, target) => {
     const date = new Date(target.value);
-    changeSchedule(scheduleId, target.id, date);
+
+    // For evaluation with the RRule library we pretend that the date is in UTC instead of the local timezone.
+    // That is 9:00 in Europe/Copenhagen time will be evaluated as if it was 9:00 in UTC.
+    // @see https://github.com/jkbrzt/rrule#important-use-utc-dates
+    changeSchedule(scheduleId, target.id, new Date(Date.UTC(
+      date.getFullYear(),
+      date.getMonth(),
+      date.getDate(),
+      date.getHours(),
+      date.getMinutes()
+    )));
   };
 
   /**
@@ -130,7 +140,7 @@ function Schedule({ schedules, onChange }) {
    * @returns {string} - The date formatted for datetime-local.
    */
   const getDateValue = (date) => {
-    return date ? dayjs(date).format("YYYY-MM-DDTHH:mm") : "";
+    return date ? dayjs(date).utc().format("YYYY-MM-DDTHH:mm") : "";
   };
 
   /**
@@ -342,6 +352,7 @@ function Schedule({ schedules, onChange }) {
                 <div id="schedule_details" className="row">
                   <strong>{t("schedule.rrulestring")}:</strong>
                   <span>{schedule.rrule}</span>
+                  <small>{t("schedule.rrulestring-z-ignored")}</small>
                   <div className="mt-2">
                     <strong>{t("schedule.next-occurrences")}:</strong>
                     {getNextOccurrences(schedule.rruleObject).map(

--- a/src/translations/da/common.json
+++ b/src/translations/da/common.json
@@ -776,6 +776,7 @@
     "hourly": "Time",
     "minutely": "Minut",
     "rrulestring": "RRule",
+    "rrulestring-z-ignored": "Bemærk at tidszonen (Z) bliver ignoreret i evalueringen af reglen. Tidsangivelserne vil altid blive behandlet i lokal tid.",
     "dtstart": "Startdato",
     "until": "Slutdato",
     "next-occurrences": "Næste 5 forekomster",


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/2000

#### Description

- Reverted change to rrule dtstart in https://github.com/os2display/display-admin-client/commit/65762066c708f541305a48fbd6b28264dca593b5.
- Added comments about how rrules are handled.
- Added helptext explaining that Z is ignored in evaluation of rrules.

#### Screenshot of the result

<img width="888" alt="Screenshot 2024-08-06 at 12 05 01" src="https://github.com/user-attachments/assets/b302150c-25a1-443e-9b28-354d8f4e2f94">

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
