### PR TITLE
Disable live slide preview for templates with option.disableLivePreview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#287](https://github.com/os2display/display-admin-client/pull/287)
+  - Disable live slide preview for templates with option.disableLivePreview.
+
 ## [2.5.0] - 2025-05-09
 
 - [#285](https://github.com/os2display/display-admin-client/pull/285)

--- a/src/components/slide/slide-form.jsx
+++ b/src/components/slide/slide-form.jsx
@@ -402,10 +402,7 @@ function SlideForm({
               </div>
 
               {selectedTemplate?.resources?.options?.disableLivePreview && (
-                <Alert
-                  variant="secondary"
-                  className="mt-3"
-                >
+                <Alert variant="secondary" className="mt-3">
                   {t("slide-preview-disabled-preview")}
                 </Alert>
               )}

--- a/src/components/slide/slide-form.jsx
+++ b/src/components/slide/slide-form.jsx
@@ -401,40 +401,50 @@ function SlideForm({
                 </Button>
               </div>
 
-              {selectedTemplate?.resources?.component && (
-                <>
-                  {previewOrientation === "horizontal" && (
-                    <div style={{ width: "100%" }}>
-                      <RemoteComponentWrapper
-                        key="live-preview-horizontal"
-                        url={selectedTemplate?.resources?.component}
-                        slide={slide}
-                        mediaData={mediaData}
-                        showPreview={displayPreview}
-                        themeData={
-                          selectedTheme?.length > 0 ? selectedTheme[0] : {}
-                        }
-                        orientation={previewOrientation}
-                      />
-                    </div>
-                  )}
-                  {previewOrientation === "vertical" && (
-                    <div style={{ width: "56.25%" }}>
-                      <RemoteComponentWrapper
-                        key="live-preview-vertical"
-                        url={selectedTemplate?.resources?.component}
-                        slide={slide}
-                        mediaData={mediaData}
-                        showPreview={displayPreview}
-                        themeData={
-                          selectedTheme?.length > 0 ? selectedTheme[0] : {}
-                        }
-                        orientation={previewOrientation}
-                      />
-                    </div>
-                  )}
-                </>
+              {selectedTemplate?.resources?.options?.disableLivePreview && (
+                <Alert
+                  key="slide-preview-disabled-preview"
+                  variant="secondary"
+                  className="mt-3"
+                >
+                  {t("slide-preview-disabled-preview")}
+                </Alert>
               )}
+              {!selectedTemplate?.resources?.options?.disableLivePreview &&
+                selectedTemplate?.resources?.component && (
+                  <>
+                    {previewOrientation === "horizontal" && (
+                      <div style={{ width: "100%" }}>
+                        <RemoteComponentWrapper
+                          key="live-preview-horizontal"
+                          url={selectedTemplate?.resources?.component}
+                          slide={slide}
+                          mediaData={mediaData}
+                          showPreview={displayPreview}
+                          themeData={
+                            selectedTheme?.length > 0 ? selectedTheme[0] : {}
+                          }
+                          orientation={previewOrientation}
+                        />
+                      </div>
+                    )}
+                    {previewOrientation === "vertical" && (
+                      <div style={{ width: "56.25%" }}>
+                        <RemoteComponentWrapper
+                          key="live-preview-vertical"
+                          url={selectedTemplate?.resources?.component}
+                          slide={slide}
+                          mediaData={mediaData}
+                          showPreview={displayPreview}
+                          themeData={
+                            selectedTheme?.length > 0 ? selectedTheme[0] : {}
+                          }
+                          orientation={previewOrientation}
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
               {previewOverlayVisible && (
                 <>
                   {config?.previewClient && (

--- a/src/components/slide/slide-form.jsx
+++ b/src/components/slide/slide-form.jsx
@@ -403,7 +403,6 @@ function SlideForm({
 
               {selectedTemplate?.resources?.options?.disableLivePreview && (
                 <Alert
-                  key="slide-preview-disabled-preview"
                   variant="secondary"
                   className="mt-3"
                 >

--- a/src/translations/da/common.json
+++ b/src/translations/da/common.json
@@ -396,6 +396,7 @@
     }
   },
   "slide-form": {
+    "slide-preview-disabled-preview": "Forhåndsvisning ikke tilgængelig for denne skabelon",
     "preview-orientation-portrait": "Portræt (9:16)",
     "preview-orientation-landscape": "Landskab (16:9)",
     "preview-close-button": "Luk",


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/4501

#### Description

Disable live slide preview for templates with option.disableLivePreview.

#### Screenshot of the result

<img width="533" alt="Screenshot 2025-05-16 at 11 13 46" src="https://github.com/user-attachments/assets/9551162a-c45b-4a8f-b108-ca853cd52684" />

#### Checklist

- [ ] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.
