### PR TITLE
Added temporary fix to screen save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#290](https://github.com/os2display/display-admin-client/pull/290)
+  - Added temporary fix that reloads the page after a screen has been saved, to ensure fresh data is fetched.
+
 ## [2.5.1] - 2025-06-23
 
 - [#287](https://github.com/os2display/display-admin-client/pull/287)

--- a/src/components/screen/screen-manager.jsx
+++ b/src/components/screen/screen-manager.jsx
@@ -285,6 +285,9 @@ function ScreenManager({
       } else {
         navigate("/screen/list");
       }
+
+      // TODO: Remove this. Temporary fix until redux caching issues are fixed.
+      window.location.reload();
     }
   }, [isSaveSuccessPut, isSaveSuccessPost]);
 


### PR DESCRIPTION
#### Issue

https://github.com/os2display/display-admin-client/issues/289

#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/5120

#### Description

After saving a screen, the playlists, etc attached to the screen are not updated in the RTK Query cache.
This makes it look like the change has not been saved.
A page reload (ctrl+r) refreshes the data.

This PR adds a temporary solution, until the RTK Query cache issues have been resolved.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.
