### PR TITLE
6592: Fix slide media array not syncing with content on media removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- [#295](https://github.com/os2display/display-admin-client/pull/295)
+  - Fixed slide media array not syncing with content on media removal.
+
 ## [2.6.0] - 2025-12-05
 
 - [#293](https://github.com/os2display/display-admin-client/pull/293)

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -112,7 +112,7 @@ test.describe("Slide media sync", () => {
       images: ["/v2/media/1"],
       title: "Some text",
       separator: true,
-      contacts: [{ name: "John", image: ["/v2/media/2"] }],
+      contacts: [{ name: "John", image: ["/v2/media/2"], tags: ["news"] }],
     };
     const mediaFields = [];
 
@@ -120,13 +120,12 @@ test.describe("Slide media sync", () => {
 
     // images field is picked up via top-level scan
     expect(result).toContain("/v2/media/1");
-    // contacts is an array of objects, not strings — objects are skipped
-    expect(result).not.toContain("/v2/media/2");
+    expect(result).toContain("/v2/media/2");
+    expect(result).not.toContain("news");
   });
 
   test("It does not include non-media string arrays from content", () => {
-    // Regression: previously any array-of-strings could be treated as media,
-    // e.g. tags/categories/etc. Only actual media IRIs should be returned.
+    // Only actual media IRIs should be returned.
     const content = {
       images: ["/v2/media/1"],
       tags: ["news", "sports"],

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import { rebuildMediaFromContent } from "../src/components/slide/slide-media-utils";
+
+test.describe("Slide media sync", () => {
+  test("It returns media IRIs referenced in content fields", () => {
+    const content = {
+      mainImage: ["/v2/media/1", "/v2/media/2"],
+      backgroundVideo: ["/v2/media/3"],
+    };
+    const mediaFields = ["mainImage", "backgroundVideo"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/1", "/v2/media/2", "/v2/media/3"]);
+  });
+
+  test("It excludes TEMP-- IDs that have not been uploaded yet", () => {
+    const content = {
+      mainImage: ["TEMP--abc123", "/v2/media/1"],
+    };
+    const mediaFields = ["mainImage"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/1"]);
+  });
+
+  test("It removes media no longer referenced in any content field", () => {
+    // This is the core bug fix scenario: media/1 was previously in mainImage
+    // but has been replaced by media/2. The rebuilt array must NOT contain
+    // media/1 since it is no longer in any content field.
+    const content = {
+      mainImage: ["/v2/media/2"],
+    };
+    const mediaFields = ["mainImage"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/2"]);
+    expect(result).not.toContain("/v2/media/1");
+  });
+
+  test("It returns empty array when all media is removed from content", () => {
+    // Second bug fix scenario: clearing one media field used to wipe all
+    // media including those from other fields. Now it correctly rebuilds
+    // from all fields.
+    const content = {
+      mainImage: [],
+      backgroundVideo: ["/v2/media/3"],
+    };
+    const mediaFields = ["mainImage", "backgroundVideo"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/3"]);
+  });
+
+  test("It deduplicates media used across multiple content fields", () => {
+    const content = {
+      mainImage: ["/v2/media/1"],
+      thumbnail: ["/v2/media/1"],
+    };
+    const mediaFields = ["mainImage", "thumbnail"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/1"]);
+  });
+
+  test("It handles non-existent content fields gracefully", () => {
+    const content = {};
+    const mediaFields = ["mainImage"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual([]);
+  });
+
+  test("It handles nested content field paths", () => {
+    const content = {
+      sections: {
+        hero: ["/v2/media/1"],
+      },
+    };
+    const mediaFields = ["sections.hero"];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/1"]);
+  });
+});

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -138,4 +138,15 @@ test.describe("Slide media sync", () => {
     expect(result).not.toContain("news");
     expect(result).not.toContain("sports");
   });
+
+  test("It avoids infinite recursion when content contains circular references", () => {
+    const circular = { images: ["/v2/media/1"] };
+    circular.self = circular; // create an explicit cycle
+
+    // If we didn't track `seen`, this would crash.
+    expect(() => rebuildMediaFromContent(circular, [])).not.toThrow();
+
+    const result = rebuildMediaFromContent(circular, []);
+    expect(result).toContain("/v2/media/1");
+  });
 });

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -7,9 +7,8 @@ test.describe("Slide media sync", () => {
       mainImage: ["/v2/media/1", "/v2/media/2"],
       backgroundVideo: ["/v2/media/3"],
     };
-    const mediaFields = ["mainImage", "backgroundVideo"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/1", "/v2/media/2", "/v2/media/3"]);
   });
@@ -18,39 +17,30 @@ test.describe("Slide media sync", () => {
     const content = {
       mainImage: ["TEMP--abc123", "/v2/media/1"],
     };
-    const mediaFields = ["mainImage"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/1"]);
   });
 
   test("It removes media no longer referenced in any content field", () => {
-    // This is the core bug fix scenario: media/1 was previously in mainImage
-    // but has been replaced by media/2. The rebuilt array must NOT contain
-    // media/1 since it is no longer in any content field.
     const content = {
       mainImage: ["/v2/media/2"],
     };
-    const mediaFields = ["mainImage"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/2"]);
     expect(result).not.toContain("/v2/media/1");
   });
 
   test("It returns empty array when all media is removed from content", () => {
-    // Second bug fix scenario: clearing one media field used to wipe all
-    // media including those from other fields. Now it correctly rebuilds
-    // from all fields.
     const content = {
       mainImage: [],
       backgroundVideo: ["/v2/media/3"],
     };
-    const mediaFields = ["mainImage", "backgroundVideo"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/3"]);
   });
@@ -60,18 +50,16 @@ test.describe("Slide media sync", () => {
       mainImage: ["/v2/media/1"],
       thumbnail: ["/v2/media/1"],
     };
-    const mediaFields = ["mainImage", "thumbnail"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/1"]);
   });
 
   test("It handles non-existent content fields gracefully", () => {
     const content = {};
-    const mediaFields = ["mainImage"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual([]);
   });
@@ -82,57 +70,34 @@ test.describe("Slide media sync", () => {
         hero: ["/v2/media/1"],
       },
     };
-    const mediaFields = ["sections.hero"];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/1"]);
   });
 
-  test("It includes media from untracked content fields", () => {
-    // When only one media field has been touched via handleMedia,
-    // mediaFields only contains that field. Media from other content
-    // fields must still be included by scanning top-level content keys.
-    const content = {
-      images: ["/v2/media/1"],
-      backgroundImage: ["/v2/media/2"],
-    };
-    const mediaFields = ["images"]; // only images was touched
-
-    const result = rebuildMediaFromContent(content, mediaFields);
-
-    expect(result).toContain("/v2/media/1");
-    expect(result).toContain("/v2/media/2");
-  });
-
   test("It ignores non-media content values when scanning top-level keys", () => {
-    // Content has both media arrays and plain string/object values.
-    // Only string array entries should be picked up as media.
     const content = {
       images: ["/v2/media/1"],
       title: "Some text",
       separator: true,
       contacts: [{ name: "John", image: ["/v2/media/2"], tags: ["news"] }],
     };
-    const mediaFields = [];
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
-    // images field is picked up via top-level scan
     expect(result).toContain("/v2/media/1");
     expect(result).toContain("/v2/media/2");
     expect(result).not.toContain("news");
   });
 
   test("It does not include non-media string arrays from content", () => {
-    // Only actual media IRIs should be returned.
     const content = {
       images: ["/v2/media/1"],
       tags: ["news", "sports"],
     };
-    const mediaFields = []; // rely on top-level scan
 
-    const result = rebuildMediaFromContent(content, mediaFields);
+    const result = rebuildMediaFromContent(content);
 
     expect(result).toEqual(["/v2/media/1"]);
     expect(result).not.toContain("news");
@@ -143,10 +108,9 @@ test.describe("Slide media sync", () => {
     const circular = { images: ["/v2/media/1"] };
     circular.self = circular; // create an explicit cycle
 
-    // If we didn't track `seen`, this would crash.
-    expect(() => rebuildMediaFromContent(circular, [])).not.toThrow();
+    expect(() => rebuildMediaFromContent(circular)).not.toThrow();
 
-    const result = rebuildMediaFromContent(circular, []);
+    const result = rebuildMediaFromContent(circular);
     expect(result).toContain("/v2/media/1");
   });
 });

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -123,4 +123,20 @@ test.describe("Slide media sync", () => {
     // contacts is an array of objects, not strings — objects are skipped
     expect(result).not.toContain("/v2/media/2");
   });
+
+  test("It does not include non-media string arrays from content", () => {
+    // Regression: previously any array-of-strings could be treated as media,
+    // e.g. tags/categories/etc. Only actual media IRIs should be returned.
+    const content = {
+      images: ["/v2/media/1"],
+      tags: ["news", "sports"],
+    };
+    const mediaFields = []; // rely on top-level scan
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toEqual(["/v2/media/1"]);
+    expect(result).not.toContain("news");
+    expect(result).not.toContain("sports");
+  });
 });

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { rebuildMediaFromContent } from "../src/components/slide/slide-media-utils";
+import rebuildMediaFromContent from "../src/components/slide/slide-media-utils";
 
 test.describe("Slide media sync", () => {
   test("It returns media IRIs referenced in content fields", () => {

--- a/e2e/slide-media-sync.spec.js
+++ b/e2e/slide-media-sync.spec.js
@@ -88,4 +88,39 @@ test.describe("Slide media sync", () => {
 
     expect(result).toEqual(["/v2/media/1"]);
   });
+
+  test("It includes media from untracked content fields", () => {
+    // When only one media field has been touched via handleMedia,
+    // mediaFields only contains that field. Media from other content
+    // fields must still be included by scanning top-level content keys.
+    const content = {
+      images: ["/v2/media/1"],
+      backgroundImage: ["/v2/media/2"],
+    };
+    const mediaFields = ["images"]; // only images was touched
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    expect(result).toContain("/v2/media/1");
+    expect(result).toContain("/v2/media/2");
+  });
+
+  test("It ignores non-media content values when scanning top-level keys", () => {
+    // Content has both media arrays and plain string/object values.
+    // Only string array entries should be picked up as media.
+    const content = {
+      images: ["/v2/media/1"],
+      title: "Some text",
+      separator: true,
+      contacts: [{ name: "John", image: ["/v2/media/2"] }],
+    };
+    const mediaFields = [];
+
+    const result = rebuildMediaFromContent(content, mediaFields);
+
+    // images field is picked up via top-level scan
+    expect(result).toContain("/v2/media/1");
+    // contacts is an array of objects, not strings — objects are skipped
+    expect(result).not.toContain("/v2/media/2");
+  });
 });

--- a/src/components/slide/slide-manager.jsx
+++ b/src/components/slide/slide-manager.jsx
@@ -389,11 +389,11 @@ function SlideManager({
 
     set(localFormStateObject.content, fieldId, newField);
 
-    // Rebuild media array from all content fields to keep it in sync.
+    // Rebuild the media array from all content fields to keep it in sync.
     set(
       localFormStateObject,
       "media",
-      rebuildMediaFromContent(localFormStateObject.content, updatedMediaFields)
+      rebuildMediaFromContent(localFormStateObject.content)
     );
 
     setFormStateObject(localFormStateObject);

--- a/src/components/slide/slide-manager.jsx
+++ b/src/components/slide/slide-manager.jsx
@@ -2,6 +2,7 @@ import { React, useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import get from "lodash.get";
 import set from "lodash.set";
+import { rebuildMediaFromContent } from "./slide-media-utils";
 import { ulid } from "ulid";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
@@ -337,13 +338,11 @@ function SlideManager({
     const localFormStateObject = { ...formStateObject };
     const localMediaData = { ...mediaData };
     // Set field as a field to look into for new references.
-    setMediaFields([...new Set([...mediaFields, fieldId])]);
+    const updatedMediaFields = [...new Set([...mediaFields, fieldId])];
+    setMediaFields(updatedMediaFields);
 
     const newField = [];
 
-    if (Array.isArray(fieldValue) && fieldValue.length === 0) {
-      localFormStateObject.media = [];
-    }
     // Handle each entry in field.
     if (Array.isArray(fieldValue)) {
       fieldValue.forEach((entry) => {
@@ -383,17 +382,19 @@ function SlideManager({
             !Object.prototype.hasOwnProperty.call(localMediaData, entry["@id"])
           ) {
             set(localMediaData, entry["@id"], entry);
-
-            localFormStateObject.media.push(entry["@id"]);
           }
         }
       });
     }
 
     set(localFormStateObject.content, fieldId, newField);
-    set(localFormStateObject, "media", [
-      ...new Set([...localFormStateObject.media]),
-    ]);
+
+    // Rebuild media array from all content fields to keep it in sync.
+    set(
+      localFormStateObject,
+      "media",
+      rebuildMediaFromContent(localFormStateObject.content, updatedMediaFields)
+    );
 
     setFormStateObject(localFormStateObject);
     setMediaData(localMediaData);

--- a/src/components/slide/slide-manager.jsx
+++ b/src/components/slide/slide-manager.jsx
@@ -2,12 +2,12 @@ import { React, useEffect, useState, useContext } from "react";
 import { useTranslation } from "react-i18next";
 import get from "lodash.get";
 import set from "lodash.set";
-import { rebuildMediaFromContent } from "./slide-media-utils";
 import { ulid } from "ulid";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
 import dayjs from "dayjs";
 import { useNavigate } from "react-router-dom";
+import rebuildMediaFromContent from "./slide-media-utils";
 import UserContext from "../../context/user-context";
 import {
   api,

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -3,15 +3,15 @@ import get from "lodash.get";
 /**
  * Rebuild the media array from all content fields that reference media.
  *
- * This ensures that the top-level `media` array (sent to the API as
- * slide_media associations) always matches the media actually referenced
- * in the slide's `content` object.
+ * This ensures that the top-level `media` array (sent to the API as slide_media
+ * associations) always matches the media actually referenced in the slide's
+ * `content` object.
  *
  * @param {object} content - The slide content object.
  * @param {string[]} mediaFields - Field names in content that hold media refs.
  * @returns {string[]} Deduplicated array of media IRIs.
  */
-export function rebuildMediaFromContent(content, mediaFields) {
+export default function rebuildMediaFromContent(content, mediaFields) {
   const media = [];
 
   mediaFields.forEach((fieldName) => {

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -15,6 +15,11 @@ export default function rebuildMediaFromContent(content, mediaFields) {
   const media = [];
   const fieldsToScan = new Set(mediaFields);
 
+  const isMediaIri = (value) =>
+    typeof value === "string" &&
+    !value.startsWith("TEMP--") &&
+    value.includes("/v2/media/");
+
   // Also scan top-level content keys to catch media fields not yet
   // tracked via handleMedia (e.g. on first edit of another field).
   if (content && typeof content === "object") {
@@ -23,13 +28,13 @@ export default function rebuildMediaFromContent(content, mediaFields) {
 
   fieldsToScan.forEach((fieldName) => {
     const fieldData = get(content, fieldName);
-    if (Array.isArray(fieldData)) {
-      fieldData.forEach((mediaId) => {
-        if (typeof mediaId === "string" && !mediaId.startsWith("TEMP--")) {
-          media.push(mediaId);
-        }
-      });
-    }
+    if (!Array.isArray(fieldData)) return;
+
+    fieldData.forEach((candidate) => {
+      if (isMediaIri(candidate)) {
+        media.push(candidate);
+      }
+    });
   });
 
   return [...new Set(media)];

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -22,6 +22,28 @@ export default function rebuildMediaFromContent(content, mediaFields) {
     !value.startsWith("TEMP--") &&
     mediaIriRegex.test(value);
 
+  const collectMediaFromValue = (value, seen = new Set()) => {
+    if (value === null || value === undefined) return;
+
+    if (typeof value === "string") {
+      if (isMediaIri(value)) media.push(value);
+      return;
+    }
+
+    if (typeof value !== "object") return;
+
+    // Avoid potential circular references (defensive; content is usually JSON)
+    if (seen.has(value)) return;
+    seen.add(value);
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => collectMediaFromValue(item, seen));
+      return;
+    }
+
+    Object.values(value).forEach((item) => collectMediaFromValue(item, seen));
+  };
+
   // Also, scan top-level content keys to catch media fields not yet
   // tracked via handleMedia (e.g. on the first edit of another field).
   if (content && typeof content === "object") {
@@ -30,13 +52,7 @@ export default function rebuildMediaFromContent(content, mediaFields) {
 
   fieldsToScan.forEach((fieldName) => {
     const fieldData = get(content, fieldName);
-    if (!Array.isArray(fieldData)) return;
-
-    fieldData.forEach((candidate) => {
-      if (isMediaIri(candidate)) {
-        media.push(candidate);
-      }
-    });
+    collectMediaFromValue(fieldData);
   });
 
   return [...new Set(media)];

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -13,8 +13,15 @@ import get from "lodash.get";
  */
 export default function rebuildMediaFromContent(content, mediaFields) {
   const media = [];
+  const fieldsToScan = new Set(mediaFields);
 
-  mediaFields.forEach((fieldName) => {
+  // Also scan top-level content keys to catch media fields not yet
+  // tracked via handleMedia (e.g. on first edit of another field).
+  if (content && typeof content === "object") {
+    Object.keys(content).forEach((key) => fieldsToScan.add(key));
+  }
+
+  fieldsToScan.forEach((fieldName) => {
     const fieldData = get(content, fieldName);
     if (Array.isArray(fieldData)) {
       fieldData.forEach((mediaId) => {

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -1,5 +1,3 @@
-import get from "lodash.get";
-
 /**
  * Rebuild the media array from all content fields that reference media.
  *

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -1,0 +1,29 @@
+import get from "lodash.get";
+
+/**
+ * Rebuild the media array from all content fields that reference media.
+ *
+ * This ensures that the top-level `media` array (sent to the API as
+ * slide_media associations) always matches the media actually referenced
+ * in the slide's `content` object.
+ *
+ * @param {object} content - The slide content object.
+ * @param {string[]} mediaFields - Field names in content that hold media refs.
+ * @returns {string[]} Deduplicated array of media IRIs.
+ */
+export function rebuildMediaFromContent(content, mediaFields) {
+  const media = [];
+
+  mediaFields.forEach((fieldName) => {
+    const fieldData = get(content, fieldName);
+    if (Array.isArray(fieldData)) {
+      fieldData.forEach((mediaId) => {
+        if (typeof mediaId === "string" && !mediaId.startsWith("TEMP--")) {
+          media.push(mediaId);
+        }
+      });
+    }
+  });
+
+  return [...new Set(media)];
+}

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -39,7 +39,5 @@ export default function rebuildMediaFromContent(content, mediaFields) {
     });
   });
 
-  console.log("media", [...new Set(media)]);
-
   return [...new Set(media)];
 }

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -15,13 +15,15 @@ export default function rebuildMediaFromContent(content, mediaFields) {
   const media = [];
   const fieldsToScan = new Set(mediaFields);
 
+  const mediaIriRegex = /\/v2\/media\/.+/;
+
   const isMediaIri = (value) =>
     typeof value === "string" &&
     !value.startsWith("TEMP--") &&
-    value.includes("/v2/media/");
+    mediaIriRegex.test(value);
 
-  // Also scan top-level content keys to catch media fields not yet
-  // tracked via handleMedia (e.g. on first edit of another field).
+  // Also, scan top-level content keys to catch media fields not yet
+  // tracked via handleMedia (e.g. on the first edit of another field).
   if (content && typeof content === "object") {
     Object.keys(content).forEach((key) => fieldsToScan.add(key));
   }
@@ -36,6 +38,8 @@ export default function rebuildMediaFromContent(content, mediaFields) {
       }
     });
   });
+
+  console.log("media", [...new Set(media)]);
 
   return [...new Set(media)];
 }

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -8,12 +8,10 @@ import get from "lodash.get";
  * `content` object.
  *
  * @param {object} content - The slide content object.
- * @param {string[]} mediaFields - Field names in content that hold media refs.
  * @returns {string[]} Deduplicated array of media IRIs.
  */
-export default function rebuildMediaFromContent(content, mediaFields) {
+export default function rebuildMediaFromContent(content) {
   const media = [];
-  const fieldsToScan = new Set(mediaFields);
 
   const mediaIriRegex = /\/v2\/media\/.+/;
 
@@ -51,16 +49,15 @@ export default function rebuildMediaFromContent(content, mediaFields) {
     Object.values(value).forEach((item) => collectMediaFromValue(item, seen));
   };
 
-  // Also, scan top-level content keys to catch media fields not yet
-  // tracked via handleMedia (e.g. on the first edit of another field).
+  const fieldsToScan = new Set([]);
+
+  // Scan content for media references.
   if (content && typeof content === "object") {
     Object.keys(content).forEach((key) => fieldsToScan.add(key));
   }
 
-  fieldsToScan.forEach((fieldName) => {
-    const fieldData = get(content, fieldName);
-    collectMediaFromValue(fieldData);
-  });
+  // Scan the entire content object (one traversal)
+  collectMediaFromValue(content);
 
   return [...new Set(media)];
 }

--- a/src/components/slide/slide-media-utils.js
+++ b/src/components/slide/slide-media-utils.js
@@ -23,24 +23,31 @@ export default function rebuildMediaFromContent(content, mediaFields) {
     mediaIriRegex.test(value);
 
   const collectMediaFromValue = (value, seen = new Set()) => {
+    // 1) Ignore empty values early (nothing to scan)
     if (value === null || value === undefined) return;
 
+    // 2) If it's a string, it might be a media IRI; validate and collect it
     if (typeof value === "string") {
       if (isMediaIri(value)) media.push(value);
       return;
     }
 
+    // 3) If it's not an object (e.g. number/boolean/function), it cannot contain nested media
     if (typeof value !== "object") return;
 
-    // Avoid potential circular references (defensive; content is usually JSON)
+    // 4) Defensive guard against circular references:
+    //    - JSON content won't have cycles, but runtime objects might.
+    //    - If we've seen this object/array already, stop to avoid infinite recursion.
     if (seen.has(value)) return;
     seen.add(value);
 
+    // 5) If it's an array, scan each element (elements can be strings, objects, or more arrays)
     if (Array.isArray(value)) {
       value.forEach((item) => collectMediaFromValue(item, seen));
       return;
     }
 
+    // 6) Otherwise it's a plain object: scan its property values recursively
     Object.values(value).forEach((item) => collectMediaFromValue(item, seen));
   };
 


### PR DESCRIPTION
## Summary

- Fix `handleMedia()` in slide-manager which was append-only — removing or replacing media in a content field left stale IRIs in the `media` array sent to the API
- Fix clearing one media field wiping all media associations including those from other fields
- Extract `rebuildMediaFromContent()` utility that derives the media array from content fields on every change
- Add 7 Playwright tests verifying the media sync logic

## Related

Cross-reference: os2display/display-api-service#347

## Test plan

- [ ] Verify existing Playwright tests pass: `docker compose run --rm playwright npx playwright test`
- [ ] Verify new media sync tests pass: `docker compose run --rm playwright npx playwright test e2e/slide-media-sync.spec.js`
- [ ] Manual test: edit a slide, add media, remove it, save — verify the `media` array in the PUT request no longer contains the removed media
- [ ] Manual test: edit a slide with multiple media fields, clear one field — verify media from other fields are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)