### PR TITLE
#352 Feature: Add API version field to feed source form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added api_version configuration field to BRND feed source settings, allowing administrators to specify which BRND API version to use. Issue: https://github.com/os2display/display-api-service/issues/352
+
 - [#295](https://github.com/os2display/display-admin-client/pull/295)
   - Fixed slide media array not syncing with content on media removal.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Added api_version configuration field to BRND feed source settings, allowing administrators to specify which BRND API version to use. Issue: https://github.com/os2display/display-api-service/issues/352
+- [#299](https://github.com/os2display/display-admin-client/pull/299)
+  - Added api_version configuration field to BRND feed source settings, allowing administrators to specify which BRND API version to use.
 
 - [#295](https://github.com/os2display/display-admin-client/pull/295)
   - Fixed slide media array not syncing with content on media removal.

--- a/src/components/feed-sources/feed-source-manager.jsx
+++ b/src/components/feed-sources/feed-source-manager.jsx
@@ -88,6 +88,7 @@ function FeedSourceManager({
         api_base_uri: "",
         company_id: "",
         api_auth_key: "",
+        api_version: "1.0",
       },
     },
     {

--- a/src/components/feed-sources/templates/brnd-feed-type.jsx
+++ b/src/components/feed-sources/templates/brnd-feed-type.jsx
@@ -44,6 +44,16 @@ const BrndFeedType = ({ handleInput, formStateObject, mode }) => {
         }
         value={formStateObject?.api_auth_key}
       />
+
+      <FormInput
+        name="api_version"
+        type="text"
+        className="mb-2"
+        label={t("api-version")}
+        onChange={handleInput}
+        placeholder="1.0"
+        value={formStateObject?.api_version}
+      />
     </>
   );
 };
@@ -54,6 +64,7 @@ BrndFeedType.propTypes = {
     api_base_uri: PropTypes.string,
     company_id: PropTypes.string,
     api_auth_key: PropTypes.string,
+    api_version: PropTypes.string,
   }),
   mode: PropTypes.string,
 };

--- a/src/components/feed-sources/templates/brnd-feed-type.jsx
+++ b/src/components/feed-sources/templates/brnd-feed-type.jsx
@@ -2,11 +2,16 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "react-i18next";
 import FormInput from "../../util/forms/form-input";
+import Select from "../../util/forms/select";
 
 const BrndFeedType = ({ handleInput, formStateObject, mode }) => {
   const { t } = useTranslation("common", {
     keyPrefix: "brnd-feed-type",
   });
+  const apiVersionOptions = [
+    { key: "api-version-1-0", title: "1.0", value: "1.0" },
+    { key: "api-version-2-0", title: "2.0", value: "2.0" },
+  ];
 
   return (
     <>
@@ -45,14 +50,14 @@ const BrndFeedType = ({ handleInput, formStateObject, mode }) => {
         value={formStateObject?.api_auth_key}
       />
 
-      <FormInput
+      <Select
         name="api_version"
-        type="text"
-        className="mb-2"
+        formGroupClasses="mb-2"
         label={t("api-version")}
+        options={apiVersionOptions}
+        allowNull={false}
         onChange={handleInput}
-        placeholder="1.0"
-        value={formStateObject?.api_version}
+        value={formStateObject?.api_version || "1.0"}
       />
     </>
   );


### PR DESCRIPTION
#### Link to ticket

https://github.com/os2display/display-api-service/issues/352

#### Description

Client needs an option to change the API version (v1.0, v2.0, etc.) because the API versions might differ.

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
